### PR TITLE
Fixes ESv7 deprecation warning on use of "Type"

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -186,7 +186,6 @@ func syncFireFunc(entry *logrus.Entry, hook *ElasticHook) error {
 	_, err := hook.client.
 		Index().
 		Index(hook.index()).
-		Type("log").
 		BodyJson(*createMessage(entry, hook)).
 		Do(hook.ctx)
 
@@ -204,7 +203,6 @@ func makeBulkFireFunc(client *elastic.Client) (fireFunc, error) {
 	return func(entry *logrus.Entry, hook *ElasticHook) error {
 		r := elastic.NewBulkIndexRequest().
 			Index(hook.index()).
-			Type("log").
 			Doc(*createMessage(entry, hook))
 		processor.Add(r)
 		return nil


### PR DESCRIPTION
Removes use of `Type()`, for v7, which causes WARNING level messages: `[types removal] Specifying types in document index requests is deprecated, use the typeless endpoints instead`