### PR TITLE
Sync V7 fixes to master

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,5 @@
 # ElasticSearch Hook for [Logrus](https://github.com/Sirupsen/logrus) <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>
-<!-- img src="https://travis-ci.org/sohlich/elogrus.svg?branch=master" />
+<!-- img src="https://travis-ci.org/sohlich/elogrus.svg?branch=master" / -->
 
 ## FORK INFORMATION
 

--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,9 @@
 # ElasticSearch Hook for [Logrus](https://github.com/Sirupsen/logrus) <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>
-<img src="https://travis-ci.org/sohlich/elogrus.svg?branch=master" />
+<!-- img src="https://travis-ci.org/sohlich/elogrus.svg?branch=master" />
+
+## FORK INFORMATION
+
+@excalq's fork: fixes ElasticSearch v7 Deprecation warnings due to use of `Type()`.
 
 ## Releases
 **Notice that the master branch always refers to the latest version of Elastic. If you want to use stable versions of elogus, you should use the packages released via [gopkg.in](https://gopkg.in).**

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/sohlich/elogrus.v7
+module gopkg.in/excalq/elogrus.v7
 
 go 1.12
 

--- a/hook.go
+++ b/hook.go
@@ -186,7 +186,6 @@ func syncFireFunc(entry *logrus.Entry, hook *ElasticHook) error {
 	_, err := hook.client.
 		Index().
 		Index(hook.index()).
-		Type("log").
 		BodyJson(*createMessage(entry, hook)).
 		Do(hook.ctx)
 
@@ -204,7 +203,6 @@ func makeBulkFireFunc(client *elastic.Client) (fireFunc, error) {
 	return func(entry *logrus.Entry, hook *ElasticHook) error {
 		r := elastic.NewBulkIndexRequest().
 			Index(hook.index()).
-			Type("log").
 			Doc(*createMessage(entry, hook))
 		processor.Add(r)
 		return nil


### PR DESCRIPTION
* Removes `Type("log")` as it spams deprecation warnings in ElasticSearch v7
* Update go.mod